### PR TITLE
Make 'canned' an optional config setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ process.on('uncaughtException', function (err) {
 });
 
 function cannedResponseHandler(req, res) {
-	if (!routeConfig.canned[req.url])
+        if (!routeConfig.canned || !routeConfig.canned[req.url])
 		return false;
 
 	var file = path.join(__dirname, routeConfig.canned[req.url]);


### PR DESCRIPTION
Slightly easier to set up a config file for a transparent proxy if you don't need the canned responses feature.
