### PR TITLE
Dockerize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules
 
 config.json
 canned/*.json
+
+.vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:12.04
+
+RUN apt-get update
+
+RUN apt-get install -y build-essential
+RUN apt-get install -y curl openssl libreadline6 libreadline6-dev curl zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev ncurses-dev automake libtool bison subversion pkg-config git
+
+# Install node
+RUN curl https://raw.github.com/creationix/nvm/master/install.sh | HOME=/root sh
+RUN echo '[[ -s /root/.nvm/nvm.sh ]] && . /root/.nvm/nvm.sh' > /etc/profile.d/nvm.sh
+RUN /bin/bash -l -c "nvm install 0.11"
+RUN /bin/bash -l -c "nvm alias default 0.11"
+
+ADD . /var/www
+
+WORKDIR /var/www
+
+RUN /bin/bash -l -c "npm install"
+
+ENTRYPOINT ["./proxy.sh"]
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ $ npm install mattpardee/node-api-proxy
 $ node node_modules/node-api-proxy/index.js ../../configs/proxy.json
 ```
 
+### Alternative using Docker
+
+If you have VirtualBox and Vagrant 1.4 or higher installed, you can also
+launch the proxy without having to install node or the node modules
+
+    ./dockerup.sh ./config.json
+
 ##How to Use
 
 Using Node API Proxy is a relatively simple process of updating

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+
+  config.vm.network "forwarded_port", guest: 4040, host: 4040
+
+  config.vm.provision "docker",
+    images: ["ubuntu"]
+
+  config.vm.provision "shell",
+    inline: "cd /vagrant && docker build -t node-api-proxy . && echo '#{instructions}'"
+end
+
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
     images: ["ubuntu"]
 
   config.vm.provision "shell",
-    inline: "cd /vagrant && docker build -t node-api-proxy . && echo '#{instructions}'"
+    inline: "cd /vagrant && docker build -t node-api-proxy ."
 end
 
 

--- a/dockerup.sh
+++ b/dockerup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Invoke with a config file:
+# ./dockerup.sh ./proxy.json
+
+set -e
+set -x
+
+if ! vagrant status | grep "default *running "
+then
+  vagrant up
+else
+  vagrant provision
+fi
+
+vagrant ssh -c "docker run -i -t -p 4040:4040 node-api-proxy $1"
+
+

--- a/proxy.sh
+++ b/proxy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /etc/profile.d/nvm.sh
+
+node index.js $1


### PR DESCRIPTION
Provides a Dockerfile and scripts to allow launching the proxy without needing to worry about installing node or any npm modules (of course it replaces those dependencies with VirtualBox and Vagrant 1.4+ dependencies :smile: )

Launch with:

```
./dockerup.sh ./config.json
```
